### PR TITLE
Init QueryClientProvider

### DIFF
--- a/src/vue/QueryClientProvider.tsx
+++ b/src/vue/QueryClientProvider.tsx
@@ -1,0 +1,19 @@
+import { provide, inject, onMounted, onUnmounted, toRefs, readonly } from 'vue';
+
+import { QueryClient } from '../core'
+
+const QueryClientSymbol = Symbol('Query provider identifier');
+
+export const useQueryClient = (): QueryClient | undefined => inject(QueryClientSymbol);
+
+export const useQueryClientProvider = (client: QueryClient): void => {
+  provide(QueryClientSymbol, toRefs(readonly(client)));
+
+  onMounted(() => {
+    client.mount();
+  });
+
+  onUnmounted(() => {
+    client.unmount();
+  });
+}


### PR DESCRIPTION
QueryClientProvider is now a hook. We can create it as a component as in react version. Discussuion is welcomed.